### PR TITLE
fix: My Library 페이지에서 workspaceTitle 받아오기

### DIFF
--- a/src/page/library.tsx
+++ b/src/page/library.tsx
@@ -72,6 +72,7 @@ const Library = () => {
                                 }}}
                                 onClick={()=> {
                                     sessionStorage.setItem('workspaceId', String(paper.workspaceId))
+                                    sessionStorage.setItem('workspaceTitle', paper.workspaceTitle)
                                     if (process.env.NODE_ENV === 'production') { 
                                       amplitude.track("Library에서 Worspace 이동 버튼 클릭")
                                     }


### PR DESCRIPTION
My Library에서 워크스펭이스 이동시 워크스페이스 제목을 안받아오는 버그 해결